### PR TITLE
Use a dedicated daemon user with uid 1001

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -188,16 +188,15 @@ lazy val dockerSettings = Def.settings(
         "RUN",
         s"apk --no-cache add bash shadow git ca-certificates maven && wget $sbtUrl && tar -xf $sbtTgz && rm -f $sbtTgz"
       ),
-      Cmd("RUN", "usermod -d /opt/scala-steward daemon"),
-      Cmd("USER", "daemon")
+      Cmd("RUN", "addgroup -g 1002 scala-steward"),
+      Cmd("RUN", "usermod -d /opt/scala-steward -aG 1002 demiourgos728"),
+      Cmd("USER", "demiourgos728")
     )
   },
   Docker / packageName := name.value,
   dockerUpdateLatest := true,
   dockerEntrypoint += "--disable-sandbox",
   dockerEnvVars := Map("PATH" -> "/opt/docker/sbt/bin:${PATH}"),
-  daemonUserUid in Docker := None,
-  daemonUser in Docker := "daemon",
   dockerRepository := sys.env.get("AWS_ECR_URI")
 )
 


### PR DESCRIPTION
I've changed the dockerfile definition again to use the default user in the docker image.

The `demiourgos728` user is created by sbt-native-packager and it has uid 1001, which aligns perfectly with the uid of the `cicrleci` user. I've also added another user group with gid 1002, which corresponds to the `circleci` gid so that we don't have to fiddle with user permissions of the mounted volume (home directory).