### PR TITLE
Publish only the core module

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
           name: Publish docker image
           command: |
             `aws ecr get-login --registry-ids $AWS_ACCOUNT_ID --no-include-email --region eu-west-1`
-            sbt docker:publish < /dev/null
+            sbt core/docker:publish < /dev/null
   rotate-aws-keys:
     docker:
       - image: circleci/python:3-buster


### PR DESCRIPTION
This will stop the mill plugin from being published (... and failing, since we don't have a sonatype repo set up).

See https://app.circleci.com/pipelines/github/ovotech/scala-steward/105/workflows/334a5a04-6a3e-4000-b0b7-9ac12d0de16c/jobs/134/parallel-runs/0/steps/0-106